### PR TITLE
docs: fix meta filter condition in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2839,7 +2839,7 @@ new HtmlBundlerPlugin({
         filter: ({ attributes }) => {
           const attrName = 'property';
           const attrValues = ['og:image', 'og:video']; // allowed values of the property
-          if (attributes[attrName] && attrValues.indexOf(attributes[attrName]) < 0) {
+          if (!attributes[attrName] || attrValues.indexOf(attributes[attrName]) < 0) {
             return false; // return false to disable processing
           }
           // return true or undefined to enable processing


### PR DESCRIPTION
Fix meta filter condition, which return undefined (= true) if property does not exists

## Types of changes

<!-- Please place an `x` in all [ ] that apply: -->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **docs change**
- [ ] **breaking change** <!-- fix or feature that change existing functionality -->

## Motivation / Use-Case

Import images from meta og:image

