### PR TITLE
chore: Add CI workflow name to display Node.js and OS versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
         node-version: [18, 20, 22]
 
     runs-on: ${{ matrix.os }}
+    name: integration - Node ${{ matrix.node-version }} on ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Types of changes

<!-- Please place an `x` in all [ ] that apply: -->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **docs change**
- [ ] **breaking change** <!-- fix or feature that change existing functionality -->

## Motivation / Use-Case

This change enhances the clarity and utility of GitHub workflows by embedding critical information-like the Node.js version and operating system-directly into the workflow name. Here's how it can be useful:

* Immediate Insights: When you view workflow runs, you'll instantly see which Node.js version and OS were used, without needing to dig into logs or configurations.
* Easier Debugging: If a workflow fails, this added detail helps you quickly pinpoint potential issues related to specific environments.
* Better Organization: It makes CI pipelines more readable and organized.

This small tweak can save time and reduce potential confusion—essentially making CI workflow output more user-friendly.
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

## Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

## Additional Info

---

## Checklist

<!-- Go over all the following points, and place an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG.md**.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Appreciation for the useful project

- [x] Do not forget to give a star ⭐
