### PR TITLE
feat: Case-insensitive preprocessor patterns

### DIFF
--- a/src/Loader/Preprocessors/Ejs/index.js
+++ b/src/Loader/Preprocessors/Ejs/index.js
@@ -130,4 +130,4 @@ const preprocessor = (loaderContext, options) => {
 };
 
 module.exports = preprocessor;
-module.exports.test = /\.(html|ejs)$/;
+module.exports.test = /\.(html|ejs)$/i;

--- a/src/Loader/Preprocessors/Eta/index.js
+++ b/src/Loader/Preprocessors/Eta/index.js
@@ -132,4 +132,4 @@ const preprocessor = (loaderContext, options) => {
 };
 
 module.exports = preprocessor;
-module.exports.test = /\.(html|eta)$/;
+module.exports.test = /\.(html|eta)$/i;

--- a/src/Loader/Preprocessors/Handlebars/index.js
+++ b/src/Loader/Preprocessors/Handlebars/index.js
@@ -295,4 +295,4 @@ const preprocessor = (loaderContext, options) => {
 };
 
 module.exports = preprocessor;
-module.exports.test = /\.(html|hbs|handlebars)$/;
+module.exports.test = /\.(html|hbs|handlebars)$/i;

--- a/src/Loader/Preprocessors/Nunjucks/index.js
+++ b/src/Loader/Preprocessors/Nunjucks/index.js
@@ -138,4 +138,4 @@ const preprocessor = (loaderContext, options = {}, { esModule, watch }) => {
 };
 
 module.exports = preprocessor;
-module.exports.test = /\.(html|njk)$/;
+module.exports.test = /\.(html|njk)$/i;

--- a/src/Loader/Preprocessors/Pug/index.js
+++ b/src/Loader/Preprocessors/Pug/index.js
@@ -74,4 +74,4 @@ const preprocessor = (loaderContext, options, { esModule, watch }) => {
 };
 
 module.exports = preprocessor;
-module.exports.test = /\.(pug|jade)$/;
+module.exports.test = /\.(pug|jade)$/i;

--- a/src/Loader/Preprocessors/Tempura/index.js
+++ b/src/Loader/Preprocessors/Tempura/index.js
@@ -135,4 +135,4 @@ const preprocessor = (loaderContext, options) => {
 };
 
 module.exports = preprocessor;
-module.exports.test = /\.(html|hbs|tmpr)$/;
+module.exports.test = /\.(html|hbs|tmpr)$/i;

--- a/src/Loader/Preprocessors/Twig/index.js
+++ b/src/Loader/Preprocessors/Twig/index.js
@@ -177,4 +177,4 @@ const preprocessor = (loaderContext, options) => {
 };
 
 module.exports = preprocessor;
-module.exports.test = /\.(html|twig)$/;
+module.exports.test = /\.(html|twig)$/i;


### PR DESCRIPTION
## Types of changes

<!-- Please place an `x` in all [ ] that apply: -->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **docs change**
- [ ] **breaking change** <!-- fix or feature that change existing functionality -->

## Motivation / Use-Case

This PR introduces case-insensitive file extension matching for all supported template preprocessors. Currently, the plugin enforces strict case-sensitive regex patterns (e.g., `.html`, `.hbs`), which causes issues when projects use uppercase extensions (e.g., `.HTML`, `.HBS`) or mixed-case filenames. By adding the `i` flag to default regex patterns, we:  
- Improve developer experience by reducing case-related errors.  
- Align with common filesystem case-insensitivity conventions (e.g., macOS).  
- Ensure consistent behavior across different operating systems.  

This change addresses user-reported frustrations where templates were ignored due to case mismatches.  

---

## Additional Info
- **Modified Preprocessors**:  
  Eta, EJS, Handlebars, Nunjucks, Pug, Twig, Tempura.  

---

## Checklist

<!-- Go over all the following points, and place an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG.md**.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Appreciation for the useful project

- [x] Do not forget to give a star ⭐
