### PR TITLE
fix: stripComments handles RegExp literals (#180)

### DIFF
--- a/test/cases/_preprocessor/js-tmpl-hbs-compile-helpers-strict/src/helpers/my-helpers.js
+++ b/test/cases/_preprocessor/js-tmpl-hbs-compile-helpers-strict/src/helpers/my-helpers.js
@@ -40,7 +40,7 @@ const complexHelper = function (content, options) {
   const SEP = /(\s|&nbsp;|<br\s*\/?>)+/gi;
   const parts = content.split(SEP).filter(Boolean);
   const lastWord = parts.pop() || '';
-  const firstPart = parts.join('');
+  const firstPart = parts.join(''); // magic comment
 
   if (!firstPart.trim()) {
     out = `<p class="title">${escapeHTML(lastWord)}</p>`;


### PR DESCRIPTION
## Types of changes

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update**
- [ ] **typo fix**
- [ ] **docs change**
- [ ] **breaking change**

## Motivation / Use-Case

This PR fixes a bug in the `stripComments` function, which incorrectly treated comment-like syntax (`//`, `/* */`)
inside regular expressions as actual comments. This led to invalid output JS when processing `.hbs` templates with
helper files containing such patterns.

Example that caused the error:

```js
const SEP = /(\s|&nbsp;|<br\s*\/?>)+/gi;
const firstPart = parts.join(''); // magic comment
```

In large projects, this resulted in:

```
Module parse failed: Unexpected token
result.push is not a function
```

This PR resolves [#180](https://github.com/webdiscus/html-bundler-webpack-plugin/issues/180) by improving the parsing logic
to recognize and correctly skip over RegExp literals, including those containing `//`, `/*`, and character classes.

## Breaking Changes

None.

## Additional Info

This is my first detailed pull request — I hope everything is correct!  
Let me know if anything needs to be changed — happy to fix it.

---

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG.md**.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Appreciation for the useful project

- [x] Do not forget to give a star ⭐
