### PR TITLE
fix(Option): guard isScript and isStyle against null resource

### DIFF
--- a/src/Plugin/Option.js
+++ b/src/Plugin/Option.js
@@ -594,6 +594,7 @@ class Option {
    * @return {boolean}
    */
   isStyle(resource) {
+    if (resource == null) return false;
     const [file] = resource.split('?', 1);
     return this.options.css.enabled && this.options.css.test.test(file);
   }
@@ -603,6 +604,7 @@ class Option {
    * @return {boolean}
    */
   isScript(resource) {
+    if (resource == null) return false;
     const [file] = resource.split('?', 1);
     return this.options.js.enabled && this.options.js.test.test(file);
   }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1481,6 +1481,18 @@ describe('plugin options unit tests', () => {
     return expect(received).toEqual(true);
   });
 
+  test('isScript null resource', () => {
+    option.options = {
+      js: {
+        enabled: true,
+        test: option.js.test,
+      },
+    };
+
+    const received = option.isScript(null);
+    return expect(received).toEqual(false);
+  });
+
   test('getEntryPath', () => {
     option.dynamicEntry = 'src/views/';
     option.options.entry = option.dynamicEntry;


### PR DESCRIPTION
Closes #191.

In webpack watch mode, `MultiCompiler` propagates invalidate events with `null` as the filename, and `AssetCompiler.invalidate` passes that through to `Option.isScript`. The current `resource.split('?', 1)` crashes with TypeError and terminates the watcher when any source file is deleted. Bail out with `false` when `resource` is `null` so deletions don't kill watch mode.